### PR TITLE
UI Fixesd: Missing Logo, Navbar Overlap, and Copyright Line #225

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,6 +479,9 @@
                     <p>1-888-299-2000 <br> med </p>
                 </div>
             </div>
+            <footer>
+                <p class="m-0" style="text-align: center; padding-top: 10px;">&copy; 2024 Swasthya Point</p>
+              </footer>
         </div>
     </footer>
 

--- a/nearby.html
+++ b/nearby.html
@@ -30,6 +30,7 @@
     .lead {
       font-size: 3rem;
       color: #311f1f;
+      margin-top: 15px;
       font-weight: bold;
       text-align: center;
     }
@@ -65,9 +66,10 @@
     }
 
     .hospital-name {
-      font-size: 1.8rem;
+      font-size: 1.65rem;
       font-weight: bold;
       margin-top: 10px;
+      margin-left: -11px;
       white-space: nowrap;
       text-overflow: ellipsis;
     }
@@ -100,7 +102,7 @@
   <header>
     <input type="checkbox" name="" id="toggler">
     <label for="toggler" class="fas fa-bars"></label>
-    <a href="#" class="logo">Swasthya Point<span>.</span></a>
+    <a class="logo"><img src="img/swasthya-logo.png"></a>
 
     <nav class="navbar">
       <a href="index.html">Home</a>


### PR DESCRIPTION

Logo: The logo has been restored to the navbar.
Text Overlap: The "Find Nearby Clinic" text no longer overlaps with the navbar.
Hospital Name Alignment: The hospital name was overflowing out of its box; alignment has been adjusted accordingly.
![image](https://github.com/user-attachments/assets/2fe640d9-a8fe-4401-be67-8bd2a813130d)


Copyright Line: A copyright line has been added to the footer.
![image](https://github.com/user-attachments/assets/6096e1e1-3236-4dfb-b90d-fe405eb1051a)

Issue of #225 has been resolved.
